### PR TITLE
Avoid adding template arguments to well model classes.

### DIFF
--- a/opm/autodiff/BlackoilWellModel.hpp
+++ b/opm/autodiff/BlackoilWellModel.hpp
@@ -70,9 +70,7 @@ END_PROPERTIES
 namespace Opm {
 
         /// Class for handling the blackoil well model.
-        template<typename TypeTag,
-                 typename VFPInjProp=VFPInjProperties,
-                 typename VFPProdProp=VFPProdProperties>
+        template<typename TypeTag>
         class BlackoilWellModel : public Ewoms::BaseAuxiliaryModule<TypeTag>
         {
         public:
@@ -275,7 +273,7 @@ namespace Opm {
 
             bool wells_active_;
 
-            using WellInterfacePtr = std::unique_ptr<WellInterface<TypeTag,VFPInjProperties,VFPProdProperties>>;
+            using WellInterfacePtr = std::unique_ptr<WellInterface<TypeTag> >;
             // a vector of all the wells.
             std::vector<WellInterfacePtr > well_container_;
 
@@ -304,7 +302,7 @@ namespace Opm {
             bool initial_step_;
 
             std::unique_ptr<RateConverterType> rateConverter_;
-            std::unique_ptr<VFPProperties<VFPInjProp,VFPProdProp>> vfp_properties_;
+            std::unique_ptr<VFPProperties<VFPInjProperties,VFPProdProperties>> vfp_properties_;
 
             SimulatorReport last_report_;
 

--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -2,8 +2,8 @@
 
 
 namespace Opm {
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    template<typename TypeTag>
+    BlackoilWellModel<TypeTag>::
     BlackoilWellModel(Simulator& ebosSimulator)
         : ebosSimulator_(ebosSimulator)
         , has_solvent_(GET_PROP_VALUE(TypeTag, EnableSolvent))
@@ -14,9 +14,9 @@ namespace Opm {
             terminal_output_ = EWOMS_GET_PARAM(TypeTag, bool, EnableTerminalOutput);
     }
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     init(const Opm::EclipseState& eclState, const Opm::Schedule& schedule)
     {
         gravity_ = ebosSimulator_.problem().gravity()[2];
@@ -48,9 +48,9 @@ namespace Opm {
         ebosSimulator_.model().addAuxiliaryModule(this);
     }
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     addNeighbors(std::vector<NeighborSet>& neighbors) const
     {
         if (!param_.matrix_add_well_contributions_) {
@@ -91,9 +91,9 @@ namespace Opm {
         }
     }
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     linearize(JacobianMatrix& mat , GlobalEqVector& res)
     {
         if (!localWellsActive())
@@ -114,9 +114,9 @@ namespace Opm {
     }
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     beginReportStep(const int timeStepIdx)
     {
         const Grid& grid = ebosSimulator_.vanguard().grid();
@@ -196,7 +196,7 @@ namespace Opm {
         computeRESV(timeStepIdx);
 
         // update VFP properties
-        vfp_properties_.reset (new VFPProperties<VFPInjProp,VFPProdProp> (
+        vfp_properties_.reset (new VFPProperties<VFPInjProperties,VFPProdProperties> (
                                    schedule().getVFPInjTables(timeStepIdx),
                                    schedule().getVFPProdTables(timeStepIdx)) );
 
@@ -206,9 +206,9 @@ namespace Opm {
 
 
     // called at the beginning of a time step
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     beginTimeStep() {
         well_state_ = previous_well_state_;
 
@@ -251,9 +251,9 @@ namespace Opm {
     }
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::wellTesting(const int timeStepIdx, const double simulationTime) {
+    BlackoilWellModel<TypeTag>::wellTesting(const int timeStepIdx, const double simulationTime) {
         const auto& wtest_config = schedule().wtestConfig(timeStepIdx);
         if (wtest_config.size() == 0) { // there is no WTEST request
             return;
@@ -291,22 +291,22 @@ namespace Opm {
     }
 
     // called at the end of a report step
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     endReportStep() {
     }
 
     // called at the end of a report step
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     const SimulatorReport&
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     lastReport() const {return last_report_; }
 
     // called at the end of a time step
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     timeStepSucceeded(const double& simulationTime) {
         // TODO: when necessary
         rateConverter_->template defineState<ElementContext>(ebosSimulator_);
@@ -318,10 +318,10 @@ namespace Opm {
     }
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     template <class Context>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     computeTotalRatesForDof(RateVector& rate,
                             const Context& context,
                             unsigned spaceIdx,
@@ -333,9 +333,9 @@ namespace Opm {
             well->addCellRates(rate, elemIdx);
     }
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     initFromRestartFile(const RestartValue& restartValues)
     {
         // gives a dummy dynamic_list_econ_limited
@@ -371,9 +371,9 @@ namespace Opm {
         initial_step_ = false;
     }
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
-    std::vector<typename BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::WellInterfacePtr >
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    template<typename TypeTag>
+    std::vector<typename BlackoilWellModel<TypeTag>::WellInterfacePtr >
+    BlackoilWellModel<TypeTag>::
     createWellContainer(const int time_step)
     {
         std::vector<WellInterfacePtr> well_container;
@@ -427,10 +427,10 @@ namespace Opm {
                 const int pvtreg = pvt_region_idx_[well_cell_top];
 
                 if ( !well_ecl->isMultiSegment(time_step) || !param_.use_multisegment_well_) {
-                    well_container.emplace_back(new StandardWell<TypeTag,VFPInjProp,VFPProdProp>(well_ecl, time_step, wells(),
+                    well_container.emplace_back(new StandardWell<TypeTag>(well_ecl, time_step, wells(),
                                                 param_, *rateConverter_, pvtreg, numComponents() ) );
                 } else {
-                    well_container.emplace_back(new MultisegmentWell<TypeTag,VFPInjProp,VFPProdProp>(well_ecl, time_step, wells(),
+                    well_container.emplace_back(new MultisegmentWell<TypeTag>(well_ecl, time_step, wells(),
                                                 param_, *rateConverter_, pvtreg, numComponents() ) );
                 }
             }
@@ -442,9 +442,9 @@ namespace Opm {
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
-    typename BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::WellInterfacePtr
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    template<typename TypeTag>
+    typename BlackoilWellModel<TypeTag>::WellInterfacePtr
+    BlackoilWellModel<TypeTag>::
     createWellForWellTest(const std::string& well_name,
                           const int report_step) const
     {
@@ -482,10 +482,10 @@ namespace Opm {
         const int pvtreg = pvt_region_idx_[well_cell_top];
 
         if ( !well_ecl->isMultiSegment(report_step) || !param_.use_multisegment_well_) {
-             return WellInterfacePtr(new StandardWell<TypeTag,VFPInjProp,VFPProdProp>(well_ecl, report_step, wells(),
+             return WellInterfacePtr(new StandardWell<TypeTag>(well_ecl, report_step, wells(),
                                                  param_, *rateConverter_, pvtreg, numComponents() ) );
         } else {
-             return WellInterfacePtr(new MultisegmentWell<TypeTag,VFPInjProp,VFPProdProp>(well_ecl, report_step, wells(),
+             return WellInterfacePtr(new MultisegmentWell<TypeTag>(well_ecl, report_step, wells(),
                                                  param_, *rateConverter_, pvtreg, numComponents() ) );
         }
     }
@@ -494,9 +494,9 @@ namespace Opm {
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     assemble(const int iterationIdx,
              const double dt)
     {
@@ -543,9 +543,9 @@ namespace Opm {
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     assembleWellEq(const double dt)
     {
         for (auto& well : well_container_) {
@@ -553,9 +553,9 @@ namespace Opm {
         }
     }
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     apply( BVector& r) const
     {
         if ( ! localWellsActive() ) {
@@ -569,9 +569,9 @@ namespace Opm {
 
 
     // Ax = A x - C D^-1 B x
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     apply(const BVector& x, BVector& Ax) const
     {
         // TODO: do we still need localWellsActive()?
@@ -589,9 +589,9 @@ namespace Opm {
 
 
     // Ax = Ax - alpha * C D^-1 B x
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     applyScaleAdd(const Scalar alpha, const BVector& x, BVector& Ax) const
     {
         if ( ! localWellsActive() ) {
@@ -613,9 +613,9 @@ namespace Opm {
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     recoverWellSolutionAndUpdateWellState(const BVector& x)
     {
         if (!localWellsActive())
@@ -629,9 +629,9 @@ namespace Opm {
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     resetWellControlFromState() const
     {
         for (auto& well : well_container_) {
@@ -644,9 +644,9 @@ namespace Opm {
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     bool
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     wellsActive() const
     {
         return wells_active_;
@@ -656,9 +656,9 @@ namespace Opm {
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     setWellsActive(const bool wells_active)
     {
         wells_active_ = wells_active;
@@ -668,9 +668,9 @@ namespace Opm {
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     bool
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     localWellsActive() const
     {
         return numWells() > 0;
@@ -680,9 +680,9 @@ namespace Opm {
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     initPrimaryVariablesEvaluation() const
     {
         for (auto& well : well_container_) {
@@ -694,9 +694,9 @@ namespace Opm {
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     SimulatorReport
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     solveWellEq(const double dt)
     {
         const int nw = numWells();
@@ -769,9 +769,9 @@ namespace Opm {
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     bool
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     getWellConvergence(const std::vector<Scalar>& B_avg) const
     {
         ConvergenceReport report;
@@ -835,9 +835,9 @@ namespace Opm {
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     calculateExplicitQuantities() const
     {
          for (auto& well : well_container_) {
@@ -849,9 +849,9 @@ namespace Opm {
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     updateWellControls()
     {
         // Even if there no wells active locally, we cannot
@@ -875,9 +875,9 @@ namespace Opm {
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     updateWellTestState(const double& simulationTime, WellTestState& wellTestState) const
     {
         for (const auto& well : well_container_) {
@@ -887,9 +887,9 @@ namespace Opm {
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     computeWellPotentials(std::vector<double>& well_potentials)
     {
         // number of wells and phases
@@ -912,9 +912,9 @@ namespace Opm {
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     prepareTimeStep()
     {
 
@@ -960,9 +960,9 @@ namespace Opm {
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     prepareGroupControl()
     {
         // group control related processing
@@ -1017,36 +1017,36 @@ namespace Opm {
         }
     }
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     const WellCollection&
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     wellCollection() const
     {
         return wells_manager_->wellCollection();
     }
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     WellCollection&
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     wellCollection()
     {
         return wells_manager_->wellCollection();
     }
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
-    const typename BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::WellState&
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    template<typename TypeTag>
+    const typename BlackoilWellModel<TypeTag>::WellState&
+    BlackoilWellModel<TypeTag>::
     wellState() const { return well_state_; }
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
-    const typename BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::WellState&
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    template<typename TypeTag>
+    const typename BlackoilWellModel<TypeTag>::WellState&
+    BlackoilWellModel<TypeTag>::
     wellState(const WellState& well_state OPM_UNUSED) const { return wellState(); }
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     calculateEfficiencyFactors()
     {
         if ( !localWellsActive() ) {
@@ -1067,9 +1067,9 @@ namespace Opm {
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     computeWellVoidageRates(std::vector<double>& well_voidage_rates,
                             std::vector<double>& voidage_conversion_coeffs) const
     {
@@ -1130,9 +1130,9 @@ namespace Opm {
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     applyVREPGroupControl()
     {
         if ( wellCollection().havingVREPGroups() ) {
@@ -1158,9 +1158,9 @@ namespace Opm {
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     updateGroupControls()
     {
 
@@ -1198,9 +1198,9 @@ namespace Opm {
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     setupCartesianToCompressed_(const int* global_cell, int number_of_cartesian_cells)
     {
         cartesian_to_compressed_.resize(number_of_cartesian_cells, -1);
@@ -1217,9 +1217,9 @@ namespace Opm {
 
     }
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     computeRepRadiusPerfLength(const Grid& grid)
     {
         for (const auto& well : well_container_) {
@@ -1231,9 +1231,9 @@ namespace Opm {
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     computeAverageFormationFactor(std::vector<double>& B_avg) const
     {
         const auto& grid = ebosSimulator_.vanguard().grid();
@@ -1279,9 +1279,9 @@ namespace Opm {
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     updatePrimaryVariables()
     {
         for (const auto& well : well_container_) {
@@ -1289,9 +1289,9 @@ namespace Opm {
         }
     }
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::extractLegacyCellPvtRegionIndex_()
+    BlackoilWellModel<TypeTag>::extractLegacyCellPvtRegionIndex_()
     {
         const auto& grid = ebosSimulator_.vanguard().grid();
         const auto& eclProblem = ebosSimulator_.problem();
@@ -1305,9 +1305,9 @@ namespace Opm {
     }
 
     // The number of components in the model.
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     int
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::numComponents() const
+    BlackoilWellModel<TypeTag>::numComponents() const
     {
         if (numPhases() == 2) {
             return 2;
@@ -1320,23 +1320,23 @@ namespace Opm {
         return numComp;
     }
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     int
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>:: numWells() const
+    BlackoilWellModel<TypeTag>:: numWells() const
     {
         return wells() ? wells()->number_of_wells : 0;
     }
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     int
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>:: numPhases() const
+    BlackoilWellModel<TypeTag>:: numPhases() const
     {
         return wells() ? wells()->number_of_phases : 1;
     }
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::extractLegacyDepth_()
+    BlackoilWellModel<TypeTag>::extractLegacyDepth_()
     {
         const auto& grid = ebosSimulator_.vanguard().grid();
         const unsigned numCells = grid.size(/*codim=*/0);
@@ -1348,9 +1348,9 @@ namespace Opm {
         }
     }
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     updatePerforationIntensiveQuantities() {
         ElementContext elemCtx(ebosSimulator_);
         const auto& gridView = ebosSimulator_.gridView();
@@ -1365,9 +1365,9 @@ namespace Opm {
     }
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    BlackoilWellModel<TypeTag,VFPInjProp,VFPProdProp>::
+    BlackoilWellModel<TypeTag>::
     computeRESV(const std::size_t step)
     {
         typedef SimFIBODetails::WellMap WellMap;

--- a/opm/autodiff/MultisegmentWell.hpp
+++ b/opm/autodiff/MultisegmentWell.hpp
@@ -28,11 +28,11 @@
 namespace Opm
 {
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
-    class MultisegmentWell: public WellInterface<TypeTag,VFPInjProps,VFPProdProps>
+    template<typename TypeTag>
+    class MultisegmentWell: public WellInterface<TypeTag>
     {
     public:
-        typedef WellInterface<TypeTag,VFPInjProps,VFPProdProps> Base;
+        typedef WellInterface<TypeTag> Base;
         typedef typename GET_PROP_TYPE(TypeTag, RateVector) RateVector;
 
         using typename Base::WellState;

--- a/opm/autodiff/MultisegmentWell_impl.hpp
+++ b/opm/autodiff/MultisegmentWell_impl.hpp
@@ -25,8 +25,8 @@ namespace Opm
 {
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    template <typename TypeTag>
+    MultisegmentWell<TypeTag>::
     MultisegmentWell(const Well* well, const int time_step, const Wells* wells,
                      const ModelParameters& param,
                      const RateConverterType& rate_converter,
@@ -104,9 +104,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     init(const PhaseUsage* phase_usage_arg,
          const std::vector<double>& depth_arg,
          const double gravity_arg,
@@ -139,9 +139,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     initMatrixAndVectors(const int num_cells) const
     {
         duneB_.setBuildMode( OffDiagMatWell::row_wise );
@@ -213,9 +213,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     initPrimaryVariablesEvaluation() const
     {
         for (int seg = 0; seg < numberOfSegments(); ++seg) {
@@ -231,9 +231,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     assembleWellEq(const Simulator& ebosSimulator,
                    const double dt,
                    WellState& well_state)
@@ -251,9 +251,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     updateWellStateWithTarget(WellState& well_state) const
     {
         // Updating well state bas on well control
@@ -379,9 +379,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     initSegmentRatesWithWellRates(WellState& well_state) const
     {
         for (int phase = 0; phase < number_of_phases_; ++phase) {
@@ -407,9 +407,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     ConvergenceReport
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     getWellConvergence(const std::vector<double>& B_avg) const
     {
         assert(int(B_avg.size()) == num_components_);
@@ -504,9 +504,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     apply(const BVector& x, BVector& Ax) const
     {
         BVectorWell Bx(duneB_.N());
@@ -524,9 +524,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     apply(BVector& r) const
     {
         // invDrw_ = duneD^-1 * resWell_
@@ -539,9 +539,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     recoverWellSolutionAndUpdateWellState(const BVector& x,
                                           WellState& well_state) const
     {
@@ -554,9 +554,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     computeWellPotentials(const Simulator& /* ebosSimulator */,
                           const WellState& /* well_state */,
                           std::vector<double>& /* well_potentials */)
@@ -568,9 +568,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     updatePrimaryVariables(const WellState& well_state) const
     {
         // TODO: to test using rate conversion coefficients to see if it will be better than
@@ -639,9 +639,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     recoverSolutionWell(const BVector& x, BVectorWell& xw) const
     {
         BVectorWell resWell = resWell_;
@@ -655,9 +655,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     solveEqAndUpdateWellState(WellState& well_state)
     {
         // We assemble the well equations, then we check the convergence,
@@ -671,9 +671,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     computePerfCellPressDiffs(const Simulator& ebosSimulator)
     {
         for (int perf = 0; perf < number_of_perforations_; ++perf) {
@@ -726,9 +726,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     computeInitialComposition()
     {
         for (int seg = 0; seg < numberOfSegments(); ++seg) {
@@ -744,9 +744,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     updateWellState(const BVectorWell& dwells,
                     const bool inner_iteration,
                     WellState& well_state) const
@@ -796,9 +796,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     calculateExplicitQuantities(const Simulator& ebosSimulator,
                                 const WellState& /* well_state */)
     {
@@ -810,9 +810,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     const WellSegments&
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     segmentSet() const
     {
         return well_ecl_->getWellSegments(current_step_);
@@ -822,9 +822,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     int
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     numberOfSegments() const
     {
         return segmentSet().size();
@@ -834,9 +834,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     int
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     numberOfPerforations() const
     {
         return segmentSet().number_of_perforations_;
@@ -846,9 +846,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     WellSegment::CompPressureDropEnum
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     compPressureDrop() const
     {
         return segmentSet().compPressureDrop();
@@ -858,9 +858,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     WellSegment::MultiPhaseModelEnum
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     multiphaseModel() const
     {
         return segmentSet().multiPhaseModel();
@@ -870,9 +870,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     int
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     segmentNumberToIndex(const int segment_number) const
     {
         return segmentSet().segmentNumberToIndex(segment_number);
@@ -882,9 +882,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
-    typename MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::EvalWell
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    template <typename TypeTag>
+    typename MultisegmentWell<TypeTag>::EvalWell
+    MultisegmentWell<TypeTag>::
     volumeFraction(const int seg, const unsigned compIdx) const
     {
 
@@ -914,9 +914,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
-    typename MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::EvalWell
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    template <typename TypeTag>
+    typename MultisegmentWell<TypeTag>::EvalWell
+    MultisegmentWell<TypeTag>::
     volumeFractionScaled(const int seg, const int comp_idx) const
     {
         // For reservoir rate control, the distr in well control is used for the
@@ -934,9 +934,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
-    typename MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::EvalWell
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    template <typename TypeTag>
+    typename MultisegmentWell<TypeTag>::EvalWell
+    MultisegmentWell<TypeTag>::
     surfaceVolumeFraction(const int seg, const int comp_idx) const
     {
         EvalWell sum_volume_fraction_scaled = 0.;
@@ -953,9 +953,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     computePerfRate(const IntensiveQuantities& int_quants,
                     const std::vector<EvalWell>& mob_perfcells,
                     const int seg,
@@ -1082,9 +1082,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
-    typename MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::EvalWell
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    template <typename TypeTag>
+    typename MultisegmentWell<TypeTag>::EvalWell
+    MultisegmentWell<TypeTag>::
     extendEval(const Eval& in) const
     {
         EvalWell out = 0.0;
@@ -1099,9 +1099,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     computeSegmentFluidProperties(const Simulator& ebosSimulator)
     {
         // TODO: the concept of phases and components are rather confusing in this function.
@@ -1269,9 +1269,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
-    typename MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::EvalWell
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    template <typename TypeTag>
+    typename MultisegmentWell<TypeTag>::EvalWell
+    MultisegmentWell<TypeTag>::
     getSegmentPressure(const int seg) const
     {
         return primary_variables_evaluation_[seg][SPres];
@@ -1281,9 +1281,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
-    typename MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::EvalWell
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    template <typename TypeTag>
+    typename MultisegmentWell<TypeTag>::EvalWell
+    MultisegmentWell<TypeTag>::
     getSegmentRate(const int seg,
                    const int comp_idx) const
     {
@@ -1294,9 +1294,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
-    typename MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::EvalWell
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    template <typename TypeTag>
+    typename MultisegmentWell<TypeTag>::EvalWell
+    MultisegmentWell<TypeTag>::
     getSegmentGTotal(const int seg) const
     {
         return primary_variables_evaluation_[seg][GTotal];
@@ -1306,9 +1306,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     getMobility(const Simulator& ebosSimulator,
                 const int perf,
                 std::vector<EvalWell>& mob) const
@@ -1362,9 +1362,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     assembleControlEq() const
     {
         EvalWell control_eq(0.0);
@@ -1446,9 +1446,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     assemblePressureEq(const int seg) const
     {
         assert(seg != 0); // not top segment
@@ -1487,9 +1487,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
-    typename MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::EvalWell
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    template <typename TypeTag>
+    typename MultisegmentWell<TypeTag>::EvalWell
+    MultisegmentWell<TypeTag>::
     getHydroPressureLoss(const int seg) const
     {
         return segment_densities_[seg] * gravity_ * segment_depth_diffs_[seg];
@@ -1499,9 +1499,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
-    typename MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::EvalWell
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    template <typename TypeTag>
+    typename MultisegmentWell<TypeTag>::EvalWell
+    MultisegmentWell<TypeTag>::
     getFrictionPressureLoss(const int seg) const
     {
         const EvalWell mass_rate = segment_mass_rates_[seg];
@@ -1523,9 +1523,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     handleAccelerationPressureLoss(const int seg) const
     {
         // TODO: this pressure loss is not significant enough to be well tested yet.
@@ -1565,9 +1565,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     processFractions(const int seg) const
     {
         const PhaseUsage& pu = phaseUsage();
@@ -1635,9 +1635,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     updateWellStateFromPrimaryVariables(WellState& well_state) const
     {
         const PhaseUsage& pu = phaseUsage();
@@ -1694,9 +1694,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     bool
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     frictionalPressureLossConsidered() const
     {
         // HF- and HFA needs to consider frictional pressure loss
@@ -1707,9 +1707,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     bool
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     accelerationalPressureLossConsidered() const
     {
         return (segmentSet().compPressureDrop() == WellSegment::HFA);
@@ -1719,9 +1719,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     iterateWellEquations(const Simulator& ebosSimulator,
                          const double dt,
                          WellState& well_state)
@@ -1762,9 +1762,9 @@ namespace Opm
 
 
 
-    template <typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    MultisegmentWell<TypeTag,VFPInjProps,VFPProdProps>::
+    MultisegmentWell<TypeTag>::
     assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
                                    const double dt,
                                    WellState& well_state)

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -31,14 +31,12 @@
 namespace Opm
 {
 
-    template<typename TypeTag,
-             typename VFPInjProps  = VFPInjProperties,
-             typename VFPProdProps = VFPProdProperties>
-    class StandardWell: public WellInterface<TypeTag,VFPInjProps,VFPProdProps>
+    template<typename TypeTag>
+    class StandardWell: public WellInterface<TypeTag>
     {
 
     public:
-        typedef WellInterface<TypeTag,VFPInjProps,VFPProdProps> Base;
+        typedef WellInterface<TypeTag> Base;
         typedef typename GET_PROP_TYPE(TypeTag, RateVector) RateVector;
 
         // TODO: some functions working with AD variables handles only with values (double) without

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -23,8 +23,8 @@
 namespace Opm
 {
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    template<typename TypeTag>
+    StandardWell<TypeTag>::
     StandardWell(const Well* well, const int time_step, const Wells* wells,
                  const ModelParameters& param,
                  const RateConverterType& rate_converter,
@@ -48,9 +48,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     init(const PhaseUsage* phase_usage_arg,
          const std::vector<double>& depth_arg,
          const double gravity_arg,
@@ -105,8 +105,8 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
-    void StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    template<typename TypeTag>
+    void StandardWell<TypeTag>::
     initPrimaryVariablesEvaluation() const
     {
         for (int eqIdx = 0; eqIdx < numWellEq; ++eqIdx) {
@@ -122,9 +122,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
-    const typename StandardWell<TypeTag,VFPInjProps,VFPProdProps>::EvalWell&
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    template<typename TypeTag>
+    const typename StandardWell<TypeTag>::EvalWell&
+    StandardWell<TypeTag>::
     getBhp() const
     {
         return primary_variables_evaluation_[Bhp];
@@ -134,9 +134,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
-    const typename StandardWell<TypeTag,VFPInjProps,VFPProdProps>::EvalWell&
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    template<typename TypeTag>
+    const typename StandardWell<TypeTag>::EvalWell&
+    StandardWell<TypeTag>::
     getWQTotal() const
     {
         return primary_variables_evaluation_[WQTotal];
@@ -146,9 +146,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
-    typename StandardWell<TypeTag,VFPInjProps,VFPProdProps>::EvalWell
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    template<typename TypeTag>
+    typename StandardWell<TypeTag>::EvalWell
+    StandardWell<TypeTag>::
     getQs(const int comp_idx) const
     {
         // Note: currently, the WQTotal definition is still depends on Injector/Producer.
@@ -183,9 +183,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
-    typename StandardWell<TypeTag,VFPInjProps,VFPProdProps>::EvalWell
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    template<typename TypeTag>
+    typename StandardWell<TypeTag>::EvalWell
+    StandardWell<TypeTag>::
     wellVolumeFractionScaled(const int compIdx) const
     {
 
@@ -202,9 +202,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
-    typename StandardWell<TypeTag,VFPInjProps,VFPProdProps>::EvalWell
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    template<typename TypeTag>
+    typename StandardWell<TypeTag>::EvalWell
+    StandardWell<TypeTag>::
     wellVolumeFraction(const unsigned compIdx) const
     {
         if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx) && compIdx == Indices::canonicalToActiveComponentIndex(FluidSystem::waterCompIdx)) {
@@ -238,9 +238,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
-    typename StandardWell<TypeTag,VFPInjProps,VFPProdProps>::EvalWell
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    template<typename TypeTag>
+    typename StandardWell<TypeTag>::EvalWell
+    StandardWell<TypeTag>::
     wellSurfaceVolumeFraction(const int compIdx) const
     {
 
@@ -258,9 +258,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
-    typename StandardWell<TypeTag,VFPInjProps,VFPProdProps>::EvalWell
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    template<typename TypeTag>
+    typename StandardWell<TypeTag>::EvalWell
+    StandardWell<TypeTag>::
     extendEval(const Eval& in) const
     {
         EvalWell out = 0.0;
@@ -275,9 +275,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     computePerfRate(const IntensiveQuantities& intQuants,
                     const std::vector<EvalWell>& mob_perfcells_dense,
                     const double Tw, const EvalWell& bhp, const double& cdp,
@@ -432,9 +432,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     assembleWellEq(const Simulator& ebosSimulator,
                    const double dt,
                    WellState& well_state)
@@ -625,9 +625,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template <typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     assembleControlEq()
     {
         EvalWell control_eq(0.0);
@@ -738,9 +738,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     bool
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     crossFlowAllowed(const Simulator& ebosSimulator) const
     {
         if (getAllowCrossFlow()) {
@@ -777,9 +777,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     getMobility(const Simulator& ebosSimulator,
                 const int perf,
                 std::vector<EvalWell>& mob) const
@@ -845,9 +845,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     updateWellState(const BVectorWell& dwells,
                     WellState& well_state) const
     {
@@ -860,9 +860,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     updatePrimaryVariablesNewton(const BVectorWell& dwells,
                                  const WellState& well_state) const
     {
@@ -916,9 +916,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     processFractions() const
     {
         assert(FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx));
@@ -996,9 +996,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     updateWellStateFromPrimaryVariables(WellState& well_state) const
     {
         const PhaseUsage& pu = phaseUsage();
@@ -1070,9 +1070,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     updateThp(WellState& well_state) const
     {
         // for the wells having a THP constaint, we should update their thp value
@@ -1119,9 +1119,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     updateWellStateWithTarget(WellState& well_state) const
     {
         // number of phases
@@ -1228,9 +1228,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     computePropertiesForWellConnectionPressures(const Simulator& ebosSimulator,
                                                 const WellState& well_state,
                                                 std::vector<double>& b_perf,
@@ -1346,9 +1346,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     computeConnectionDensities(const std::vector<double>& perfComponentRates,
                                const std::vector<double>& b_perf,
                                const std::vector<double>& rsmax_perf,
@@ -1447,9 +1447,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     computeConnectionPressureDelta()
     {
         // Algorithm:
@@ -1488,9 +1488,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     ConvergenceReport
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     getWellConvergence(const std::vector<double>& B_avg) const
     {
         // the following implementation assume that the polymer is always after the w-o-g phases
@@ -1574,9 +1574,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     computeWellConnectionDensitesPressures(const WellState& well_state,
                                            const std::vector<double>& b_perf,
                                            const std::vector<double>& rsmax_perf,
@@ -1607,9 +1607,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     computeWellConnectionPressures(const Simulator& ebosSimulator,
                                    const WellState& well_state)
     {
@@ -1628,9 +1628,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     solveEqAndUpdateWellState(WellState& well_state)
     {
         // We assemble the well equations, then we check the convergence,
@@ -1645,9 +1645,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     calculateExplicitQuantities(const Simulator& ebosSimulator,
                                 const WellState& well_state)
     {
@@ -1659,9 +1659,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     computeAccumWell()
     {
         for (int eq_idx = 0; eq_idx < numWellConservationEq; ++eq_idx) {
@@ -1673,9 +1673,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     apply(const BVector& x, BVector& Ax) const
     {
         if ( param_.matrix_add_well_contributions_ )
@@ -1701,9 +1701,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     apply(BVector& r) const
     {
         assert( invDrw_.size() == invDuneD_.N() );
@@ -1718,9 +1718,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     recoverSolutionWell(const BVector& x, BVectorWell& xw) const
     {
         BVectorWell resWell = resWell_;
@@ -1734,9 +1734,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     recoverWellSolutionAndUpdateWellState(const BVector& x,
                                           WellState& well_state) const
     {
@@ -1749,9 +1749,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     computeWellRatesWithBhp(const Simulator& ebosSimulator,
                             const EvalWell& bhp,
                             std::vector<double>& well_flux) const
@@ -1783,9 +1783,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     std::vector<double>
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     computeWellPotentialWithTHP(const Simulator& ebosSimulator,
                                 const double initial_bhp, // bhp from BHP constraints
                                 const std::vector<double>& initial_potential) const
@@ -1886,9 +1886,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     computeWellPotentials(const Simulator& ebosSimulator,
                           const WellState& well_state,
                           std::vector<double>& well_potentials) // const
@@ -1939,9 +1939,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     updatePrimaryVariables(const WellState& well_state) const
     {
         const int well_index = index_of_well_;
@@ -2030,10 +2030,10 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     template<class ValueType>
     ValueType
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     calculateBhpFromThp(const std::vector<ValueType>& rates,
                         const int control_index) const
     {
@@ -2083,9 +2083,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     double
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     calculateThpFromBhp(const std::vector<double>& rates,
                         const int control_index,
                         const double bhp) const
@@ -2130,9 +2130,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     updateWaterMobilityWithPolymer(const Simulator& ebos_simulator,
                                    const int perf,
                                    std::vector<EvalWell>& mob) const
@@ -2190,9 +2190,9 @@ namespace Opm
         }
     }
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     void
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::addWellContributions(Mat& mat) const
+    StandardWell<TypeTag>::addWellContributions(Mat& mat) const
     {
         // We need to change matrx A as follows
         // A -= C^T D^-1 B
@@ -2226,9 +2226,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     double
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     relaxationFactorFraction(const double old_value,
                              const double dx)
     {
@@ -2257,9 +2257,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     double
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     relaxationFactorFractionsProducer(const std::vector<double>& primary_variables,
                                       const BVectorWell& dwells)
     {
@@ -2301,9 +2301,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProps, typename VFPProdProps>
+    template<typename TypeTag>
     double
-    StandardWell<TypeTag,VFPInjProps,VFPProdProps>::
+    StandardWell<TypeTag>::
     relaxationFactorRate(const std::vector<double>& primary_variables,
                          const BVectorWell& dwells)
     {

--- a/opm/autodiff/WellInterface.hpp
+++ b/opm/autodiff/WellInterface.hpp
@@ -61,7 +61,7 @@ namespace Opm
 {
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     class WellInterface
     {
     public:
@@ -128,7 +128,7 @@ namespace Opm
         /// Well controls
         WellControls* wellControls() const;
 
-        void setVFPProperties(const VFPProperties<VFPInjProp,VFPProdProp>* vfp_properties_arg);
+        void setVFPProperties(const VFPProperties<VFPInjProperties,VFPProdProperties>* vfp_properties_arg);
 
         virtual void init(const PhaseUsage* phase_usage_arg,
                           const std::vector<double>& depth_arg,
@@ -285,7 +285,7 @@ namespace Opm
 
         bool getAllowCrossFlow() const;
 
-        const VFPProperties<VFPInjProp,VFPProdProp>* vfp_properties_;
+        const VFPProperties<VFPInjProperties,VFPProdProperties>* vfp_properties_;
 
         double gravity_;
 

--- a/opm/autodiff/WellInterface_impl.hpp
+++ b/opm/autodiff/WellInterface_impl.hpp
@@ -24,8 +24,8 @@ namespace Opm
 {
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::
+    template<typename TypeTag>
+    WellInterface<TypeTag>::
     WellInterface(const Well* well, const int time_step, const Wells* wells,
                   const ModelParameters& param,
                   const RateConverterType& rate_converter,
@@ -110,9 +110,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::
+    WellInterface<TypeTag>::
     init(const PhaseUsage* phase_usage_arg,
          const std::vector<double>& /* depth_arg */,
          const double gravity_arg,
@@ -126,10 +126,10 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::
-    setVFPProperties(const VFPProperties<VFPInjProp,VFPProdProp>* vfp_properties_arg)
+    WellInterface<TypeTag>::
+    setVFPProperties(const VFPProperties<VFPInjProperties,VFPProdProperties>* vfp_properties_arg)
     {
         vfp_properties_ = vfp_properties_arg;
     }
@@ -138,9 +138,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     const std::string&
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::
+    WellInterface<TypeTag>::
     name() const
     {
         return well_ecl_->name();
@@ -150,9 +150,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     WellType
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::
+    WellInterface<TypeTag>::
     wellType() const
     {
         return well_type_;
@@ -162,17 +162,17 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     WellControls*
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::
+    WellInterface<TypeTag>::
     wellControls() const
     {
         return well_controls_;
     }
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     const int
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::
+    WellInterface<TypeTag>::
     indexOfWell() const
     {
         return index_of_well_;
@@ -183,9 +183,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     bool
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::
+    WellInterface<TypeTag>::
     getAllowCrossFlow() const
     {
         return well_ecl_->getAllowCrossFlow();
@@ -194,9 +194,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::
+    WellInterface<TypeTag>::
     setWellEfficiencyFactor(const double efficiency_factor)
     {
         well_efficiency_factor_ = efficiency_factor;
@@ -204,9 +204,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     const Well*
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::
+    WellInterface<TypeTag>::
     wellEcl() const
     {
         return well_ecl_;
@@ -214,9 +214,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     const PhaseUsage&
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::
+    WellInterface<TypeTag>::
     phaseUsage() const
     {
         assert(phase_usage_);
@@ -228,9 +228,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     int
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::
+    WellInterface<TypeTag>::
     flowPhaseToEbosCompIdx( const int phaseIdx ) const
     {
         const auto& pu = phaseUsage();
@@ -245,9 +245,9 @@ namespace Opm
         return phaseIdx;
     }
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     int
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::
+    WellInterface<TypeTag>::
     ebosCompIdxToFlowCompIdx( const unsigned compIdx ) const
     {
         const auto& pu = phaseUsage();
@@ -265,9 +265,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     double
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::
+    WellInterface<TypeTag>::
     wsolvent() const
     {
         if (!has_solvent) {
@@ -288,9 +288,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     double
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::
+    WellInterface<TypeTag>::
     wpolymer() const
     {
         if (!has_polymer) {
@@ -313,9 +313,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     double
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::
+    WellInterface<TypeTag>::
     mostStrictBhpFromBhpLimits() const
     {
         double bhp;
@@ -364,9 +364,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     bool
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::
+    WellInterface<TypeTag>::
     wellHasTHPConstraints() const
     {
         const int nwc = well_controls_get_num(well_controls_);
@@ -382,9 +382,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::
+    WellInterface<TypeTag>::
     updateWellControl(WellState& well_state,
                       wellhelpers::WellSwitchingLogger& logger) const
     {
@@ -446,9 +446,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     bool
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::
+    WellInterface<TypeTag>::
     checkRateEconLimits(const WellEconProductionLimits& econ_production_limits,
                         const WellState& well_state) const
     {
@@ -497,9 +497,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
-    typename WellInterface<TypeTag,VFPInjProp,VFPProdProp>::RatioCheckTuple
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::
+    template<typename TypeTag>
+    typename WellInterface<TypeTag>::RatioCheckTuple
+    WellInterface<TypeTag>::
     checkMaxWaterCutLimit(const WellEconProductionLimits& econ_production_limits,
                           const WellState& well_state) const
     {
@@ -583,9 +583,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
-    typename WellInterface<TypeTag,VFPInjProp,VFPProdProp>::RatioCheckTuple
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::
+    template<typename TypeTag>
+    typename WellInterface<TypeTag>::RatioCheckTuple
+    WellInterface<TypeTag>::
     checkRatioEconLimits(const WellEconProductionLimits& econ_production_limits,
                          const WellState& well_state) const
     {
@@ -638,9 +638,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::
+    WellInterface<TypeTag>::
     updateWellTestState(const WellState& well_state,
                         const double& simulationTime,
                         const bool& writeMessageToOPMLog,
@@ -661,9 +661,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::
+    WellInterface<TypeTag>::
     updateWellTestStateEconomic(const WellState& well_state,
                                 const double simulation_time,
                                 const bool write_message_to_opmlog,
@@ -800,9 +800,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::
+    WellInterface<TypeTag>::
     wellTesting(Simulator& simulator, const std::vector<double>& B_avg,
                 const double simulation_time, const int report_step, const bool terminal_output,
                 const WellTestConfig::Reason testing_reason, const WellState& well_state,
@@ -818,9 +818,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::
+    WellInterface<TypeTag>::
     wellTestingEconomic(Simulator& simulator, const std::vector<double>& B_avg,
                         const double simulation_time, const int report_step, const bool terminal_output,
                         const WellState& well_state, WellTestState& welltest_state)
@@ -872,9 +872,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::
+    WellInterface<TypeTag>::
     computeRepRadiusPerfLength(const Grid& grid,
                                const std::vector<int>& cartesian_to_compressed)
     {
@@ -944,9 +944,9 @@ namespace Opm
         }
     }
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     double
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::scalingFactor(const int phaseIdx) const
+    WellInterface<TypeTag>::scalingFactor(const int phaseIdx) const
     {
         const WellControls* wc = well_controls_;
         const double* distr = well_controls_get_current_distr(wc);
@@ -979,9 +979,9 @@ namespace Opm
 
 
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::calculateReservoirRates(WellState& well_state) const
+    WellInterface<TypeTag>::calculateReservoirRates(WellState& well_state) const
     {
         const int fipreg = 0; // not considering the region for now
         const int np = number_of_phases_;
@@ -1000,9 +1000,9 @@ namespace Opm
         }    
     }
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::closeCompletions(WellTestState& wellTestState)
+    WellInterface<TypeTag>::closeCompletions(WellTestState& wellTestState)
     {
         const auto& connections = well_ecl_->getConnections(current_step_);
         int perfIdx = 0;
@@ -1014,9 +1014,9 @@ namespace Opm
         }
     }
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::solveWellForTesting(Simulator& ebosSimulator, WellState& well_state, const std::vector<double>& B_avg, bool terminal_output)
+    WellInterface<TypeTag>::solveWellForTesting(Simulator& ebosSimulator, WellState& well_state, const std::vector<double>& B_avg, bool terminal_output)
     {
         const int max_iter = param_.max_welleq_iter_;
         int it = 0;
@@ -1052,9 +1052,9 @@ namespace Opm
         }
     }
 
-    template<typename TypeTag, typename VFPInjProp, typename VFPProdProp>
+    template<typename TypeTag>
     void
-    WellInterface<TypeTag,VFPInjProp,VFPProdProp>::scaleProductivityIndex(const int perfIdx, double& productivity_index) const
+    WellInterface<TypeTag>::scaleProductivityIndex(const int perfIdx, double& productivity_index) const
     {
 
         const auto& connection = well_ecl_->getConnections(current_step_)[perfIdx];


### PR DESCRIPTION
With this, we avoid changing almost all of the well model files for ebos.